### PR TITLE
Do not escape script's to_s when it is html_safe

### DIFF
--- a/lib/fast_haml/compiler.rb
+++ b/lib/fast_haml/compiler.rb
@@ -244,7 +244,7 @@ module FastHaml
       if !ast.children.empty? && !ast.mid_block_keyword
         temple << [:code, 'end']
       end
-      temple << [:escape, ast.escape_html, [:dynamic, sym]]
+      temple << [:escape, ast.escape_html, [:dynamic, "#{sym}.to_s"]]
       temple
     end
 

--- a/spec/rails/app/models/book.rb
+++ b/spec/rails/app/models/book.rb
@@ -2,4 +2,8 @@ class Book
   include ActiveModel::Model
 
   attr_accessor :title
+
+  def to_s
+    "<span>#{title}</span>".html_safe
+  end
 end

--- a/spec/rails/app/views/books/with_variables.html.haml
+++ b/spec/rails/app/views/books/with_variables.html.haml
@@ -1,3 +1,4 @@
 %h1 Book
 %p= @book.title
 = link_to 'hello', books_hello_path
+= @book

--- a/spec/rails/spec/requests/fast_haml_spec.rb
+++ b/spec/rails/spec/requests/fast_haml_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe 'FastHaml with Rails', type: :request do
     expect(response.body).to include('<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>')
   end
 
+  it 'does not escape object which returns html_safe string by to_s' do
+    get '/books/with_variables?title=nanika'
+    expect(response.body).to include('<span>nanika</span>')
+  end
+
   it 'works with capture method' do
     get '/books/with_capture'
     expect(response).to be_ok


### PR DESCRIPTION
Kaminari does not work well with fast_haml. Kaminari paginator's html are currently escaped.
In [this line](https://github.com/amatsuda/kaminari/blob/0c354253a352150d3f2b7f7527066a8a9f64ff6d/app/views/kaminari/_paginator.html.haml#L10), `first_page_tag` returns [`Kaminari::Helpers::FirstPage`](https://github.com/amatsuda/kaminari/blob/0c354253a352150d3f2b7f7527066a8a9f64ff6d/lib/kaminari/helpers/tags.rb#L93-L98) object, whose `html_safe?` returns false. Thus fast_haml escapes it now.

But haml does not escape it because `Kaminari::Helpers::FirstPage#to_s` returns `ActiveSupport::SafeBuffer`. I think script needs to be `to_s`ed before passing it to `escape_html_safe`.

## screen shot
### haml
![](http://i.gyazo.com/fc6b1c5fd7b72edb8199c50e8f040d4c.png)

### fast_haml
![](http://i.gyazo.com/e6dbfed68585e457e1f536f22a8d8aeb.png)