### PR TITLE
Render boolean attributes

### DIFF
--- a/ext/attribute_builder/attribute_builder.c
+++ b/ext/attribute_builder/attribute_builder.c
@@ -116,7 +116,7 @@ normalize(VALUE hash)
         rb_str_buf_append(k, data_key);
         rb_hash_aset(hash, k, rb_hash_lookup(data, data_key));
       }
-    } else if (!RB_TYPE_P(value, T_TRUE)) {
+    } else if (!(RB_TYPE_P(value, T_TRUE) || RB_TYPE_P(value, T_FALSE))) {
       rb_hash_aset(hash, key, rb_funcall(value, id_to_s, 0));
     }
   }
@@ -202,6 +202,8 @@ build_attribute(VALUE attr_quote, VALUE key, VALUE value)
     rb_str_buf_cat(attr, " ", 1);
     rb_str_buf_append(attr, key);
     return attr;
+  } else if (RB_TYPE_P(value, T_FALSE)) {
+    return Qnil;
   } else {
     return put_attribute(attr_quote, key, value);
   }

--- a/lib/fast_haml/compiler.rb
+++ b/lib/fast_haml/compiler.rb
@@ -302,6 +302,8 @@ module FastHaml
       case
       when value == true
         [[:haml, :attr, key, [:multi]]]
+      when value == false
+        []
       when value.is_a?(Hash) && key == 'data'
         data = AttributeBuilder.normalize_data(value)
         data.keys.sort.map do |k|
@@ -313,7 +315,7 @@ module FastHaml
     end
 
     def compile_dynamic_attribute(key, value)
-      [[:haml, :attr, key, [:escape, true, [:dynamic, value]]]]
+      [[:haml, :attr, key, [:code, value]]]
     end
 
     def compile_script(ast)

--- a/lib/fast_haml/html.rb
+++ b/lib/fast_haml/html.rb
@@ -23,6 +23,19 @@ module FastHaml
         else
           [:static, " #{name}=#{options[:attr_quote]}#{name}#{options[:attr_quote]}"]
         end
+      elsif value[0] == :code
+        [:multi,
+          [:code, "value = (#{value[1]})"],
+          [:case, 'value',
+            ['true', [:static, " #{name}"]],
+            ['false', [:multi]],
+            [:else, [:multi,
+              [:static, " #{name}=#{options[:attr_quote]}"],
+              [:escape, true, [:dynamic, 'value']],
+              [:static, options[:attr_quote]],
+            ]],
+          ],
+        ]
       else
         [:multi,
           [:static, " #{name}=#{options[:attr_quote]}"],

--- a/spec/render/attribute_spec.rb
+++ b/spec/render/attribute_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe 'Attributes rendering', type: :render do
     expect(render_string('%span.c2{class: ["c1", "c3"]}')).to eq("<span class='c1 c2 c3'></span>\n")
   end
 
+  it "renders boolean attributes" do
+    expect(render_string('%input{checked: true}')).to eq("<input checked>\n")
+    expect(render_string('%input{checked: false}')).to eq("<input>\n")
+    expect(render_string('%input{checked: "a" == "a"}')).to eq("<input checked>\n")
+    expect(render_string('%input{checked: "a" != "a"}')).to eq("<input>\n")
+  end
+
   it 'merges classes' do
     expect(render_string(<<HAML)).to eq("<span class='c1 c2 content {}' id='main_id1_id3_id2'>hello</span>\n")
 - h1 = {class: 'c1', id: ['id1', 'id3']}
@@ -196,7 +203,6 @@ HAML
       expect(render_string(%q|%span(foo=1 bar="baz#{1 + 2}") hello|)).to eq("<span bar='baz3' foo='1'>hello</span>\n")
       expect(render_string(%q|%span(foo=1 bar='baz#{1 + 2}') hello|)).to eq("<span bar='baz3' foo='1'>hello</span>\n")
     end
-
 
     it 'parses escapes' do
       expect(render_string(%q|%span(foo=1 bar="ba\"z") hello|)).to eq("<span bar='ba&quot;z' foo='1'>hello</span>\n")

--- a/spec/render/attribute_spec.rb
+++ b/spec/render/attribute_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'Attributes rendering', type: :render do
     expect(render_string('%input{checked: false}')).to eq("<input>\n")
     expect(render_string('%input{checked: "a" == "a"}')).to eq("<input checked>\n")
     expect(render_string('%input{checked: "a" != "a"}')).to eq("<input>\n")
+    expect(render_string("- h = {checked: true}\n%input{h}")).to eq("<input checked>\n")
+    expect(render_string("- h = {checked: false}\n%input{h}")).to eq("<input>\n")
   end
 
   it 'merges classes' do


### PR DESCRIPTION
Fixed for case like:

``` haml
%input{checked: false}
%input{checked: true}
%input{checked: "a" == "a"}

- h = {checked: true}
%input{h}
```

Fix for `FastHaml::Html` is ugly, I expect better way...